### PR TITLE
Add slash commands for role/skill assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,20 @@ This file should be automatically ignored by the Git configuration.
 echo "DISCORD_TOKEN=YOUR_TOKEN_HERE" > .env
 ```
 
+Then go to the discord server which you are testing with and get the guild ID.
+Add this to your .env
+
+```bash
+echo "GUILD_ID=YOUR_GUILD_ID_HERE" > .env
+```
+
 ### Set up Permissions
 
 Finally, you'll need to give your test bot the appropriate permissions so it
 can do things. First, on the "Bot" page, turn **on** the "Server Members
 Intent" option under "Privileged Gateway Intents".
 
-Next, go to the OAuth2 page and **select "bot" under "Scopes"**. A bunch of
+Next, go to the OAuth2 page and **select "bot" and "application.command" under "Scopes"**. A bunch of
 permissions should appear below; the following are recommended settings for the
 bot permissions:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 beautifulsoup4
 praw
 pandas
+discord-py-slash-command

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import discord
+from discord_slash import SlashCommand
 from dotenv import load_dotenv
 from discord.ext import commands
 import builtins
@@ -11,8 +12,9 @@ intents.members = True
 bot = commands.Bot(
     command_prefix='!',
     activity=discord.Game('with the discord API!'),
-    intents=intents
+    intents=intents,
 )
+slash = SlashCommand(bot, sync_commands=True, sync_on_cog_reload=True)
 bot.remove_command('help')
 builtins.bot = bot
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -14,6 +14,8 @@ bot = commands.Bot(
     activity=discord.Game('with the discord API!'),
     intents=intents,
 )
+
+# Register the Slash command handler.
 slash = SlashCommand(bot, sync_commands=True, sync_on_cog_reload=True)
 bot.remove_command('help')
 builtins.bot = bot

--- a/src/cogs/khroles.py
+++ b/src/cogs/khroles.py
@@ -69,16 +69,16 @@ class KHRoles(commands.Cog):
         role = discord.utils.get(ctx.guild.roles, name=skill)
 
         if (role is None):
-            await ctx.send(f"Could not find skill with name: '{skill}'.")
+            await ctx.send(f"Could not find skill with name: '{skill}'.", hidden=True)
             return
 
         # Check prior membership
         if (role in ctx.author.roles):
-            await ctx.send(f"You are already part of {skill}.")
+            await ctx.send(f"You are already part of {skill}.", hidden=True)
             return
 
         await ctx.author.add_roles(role)
-        await ctx.send(f"Successfully added skill {skill}!")
+        await ctx.send(f"Successfully added skill {skill}!", hidden=True)
 
     @cog_ext.cog_slash(name="removeSkill", description="Removes a skill from your discord account.", guild_ids=[GUILD_ID], options=[
         create_option(
@@ -101,16 +101,16 @@ class KHRoles(commands.Cog):
         role = discord.utils.get(ctx.guild.roles, name=skill)
 
         if (role is None):
-            await ctx.send(f"Error: Could not find skill with name: '{skill}''.")
+            await ctx.send(f"Error: Could not find skill with name: '{skill}''.", hidden=True)
             return
 
         # Check prior membership
         if (role not in ctx.author.roles):
-            await ctx.send(f"You don't have the skill {skill}")
+            await ctx.send(f"You don't have the skill {skill}", hidden=True)
             return
 
         await ctx.author.remove_roles(role)
-        await ctx.send(f"Successfully removed {skill} skill!")
+        await ctx.send(f"Successfully removed {skill} skill!", hidden=True)
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/src/cogs/khroles.py
+++ b/src/cogs/khroles.py
@@ -61,7 +61,7 @@ class KHRoles(commands.Cog):
                     ), skills.values())
         )
     ])
-    async def addSkill(self, ctx: SlashContext, skill: str):
+    async def add_skill(self, ctx: SlashContext, skill: str):
         # Bot is thinking
         await ctx.defer()
 
@@ -94,7 +94,7 @@ class KHRoles(commands.Cog):
                     ), skills.values())
         )
     ])
-    async def removeSkill(self, ctx: SlashContext, skill: str):
+    async def remove_skill(self, ctx: SlashContext, skill: str):
         await ctx.defer()
 
         # Fetch role

--- a/src/cogs/khroles.py
+++ b/src/cogs/khroles.py
@@ -63,7 +63,7 @@ class KHRoles(commands.Cog):
     ])
     async def add_skill(self, ctx: SlashContext, skill: str):
         # Bot is thinking
-        await ctx.defer()
+        await ctx.defer(hidden=True)
 
         # Fetch role
         role = discord.utils.get(ctx.guild.roles, name=skill)
@@ -95,7 +95,7 @@ class KHRoles(commands.Cog):
         )
     ])
     async def remove_skill(self, ctx: SlashContext, skill: str):
-        await ctx.defer()
+        await ctx.defer(hidden=True)
 
         # Fetch role
         role = discord.utils.get(ctx.guild.roles, name=skill)

--- a/src/cogs/khroles.py
+++ b/src/cogs/khroles.py
@@ -47,31 +47,29 @@ class KHRoles(commands.Cog):
         "unity": "Unity"
     }
 
-    choices = map(
-        lambda value:
-            create_choice(
-                name=value,
-                value=value
-            ), skills.values())
-
     @cog_ext.cog_slash(name="addSkill", description="Adds a skill to your discord account.", guild_ids=[GUILD_ID], options=[
         create_option(
             name="skill",
             required=True,
             description="The skill to add.",
             option_type=3,
-            choices=choices
+            choices=map(
+                lambda value:
+                    create_choice(
+                        name=value,
+                        value=value
+                    ), skills.values())
         )
     ])
     async def addSkill(self, ctx: SlashContext, skill: str):
         # Bot is thinking
-        ctx.defer()
+        await ctx.defer()
 
         # Fetch role
         role = discord.utils.get(ctx.guild.roles, name=skill)
 
         if (role is None):
-            await ctx.send(f"Could not find skill with name: '{skill}''.")
+            await ctx.send(f"Could not find skill with name: '{skill}'.")
             return
 
         # Check prior membership
@@ -80,7 +78,39 @@ class KHRoles(commands.Cog):
             return
 
         await ctx.author.add_roles(role)
-        ctx.send(f"Successfully added skill {skill}!")
+        await ctx.send(f"Successfully added skill {skill}!")
+
+    @cog_ext.cog_slash(name="removeSkill", description="Removes a skill from your discord account.", guild_ids=[GUILD_ID], options=[
+        create_option(
+            name="skill",
+            required=True,
+            description="The skill to remove.",
+            option_type=3,
+            choices=map(
+                lambda value:
+                    create_choice(
+                        name=value,
+                        value=value
+                    ), skills.values())
+        )
+    ])
+    async def removeSkill(self, ctx: SlashContext, skill: str):
+        await ctx.defer()
+
+        # Fetch role
+        role = discord.utils.get(ctx.guild.roles, name=skill)
+
+        if (role is None):
+            await ctx.send(f"Error: Could not find skill with name: '{skill}''.")
+            return
+
+        # Check prior membership
+        if (role not in ctx.author.roles):
+            await ctx.send(f"You don't have the skill {skill}")
+            return
+
+        await ctx.author.remove_roles(role)
+        await ctx.send(f"Successfully removed {skill} skill!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/src/cogs/khroles.py
+++ b/src/cogs/khroles.py
@@ -1,11 +1,15 @@
 import discord
 from discord.ext import commands
 import os
+from discord_slash import cog_ext
+from discord_slash.context import SlashContext
+from discord_slash.utils.manage_commands import create_choice, create_option
 from dotenv import load_dotenv
 
 load_dotenv()
 LANG_MSGID = os.getenv('823687567206776862')
 OTHER_MSGID = os.getenv('823687567206776862')
+GUILD_ID = int(os.getenv('GUILD_ID'))
 
 
 class KHRoles(commands.Cog):
@@ -42,6 +46,41 @@ class KHRoles(commands.Cog):
         "aws": "AWS",
         "unity": "Unity"
     }
+
+    choices = map(
+        lambda value:
+            create_choice(
+                name=value,
+                value=value
+            ), skills.values())
+
+    @cog_ext.cog_slash(name="addSkill", description="Adds a skill to your discord account.", guild_ids=[GUILD_ID], options=[
+        create_option(
+            name="skill",
+            required=True,
+            description="The skill to add.",
+            option_type=3,
+            choices=choices
+        )
+    ])
+    async def addSkill(self, ctx: SlashContext, skill: str):
+        # Bot is thinking
+        ctx.defer()
+
+        # Fetch role
+        role = discord.utils.get(ctx.guild.roles, name=skill)
+
+        if (role is None):
+            await ctx.send(f"Could not find skill with name: '{skill}''.")
+            return
+
+        # Check prior membership
+        if (role in ctx.author.roles):
+            await ctx.send(f"You are already part of {skill}.")
+            return
+
+        await ctx.author.add_roles(role)
+        ctx.send(f"Successfully added skill {skill}!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/src/cogs/roles.py
+++ b/src/cogs/roles.py
@@ -55,8 +55,23 @@ class Roles(commands.Cog):
         )
     ])
     async def _addrole(self, ctx: SlashContext, role: str):
+        # Show the user that the bot is thinking.
         await ctx.defer()
-        await ctx.send("Pong!")
+
+        # Fetch the role from the cache.
+        role = discord.utils.get(ctx.guild.roles, name=ctx.args[0])
+
+        # This branch shouldn't happen, but just in case...
+        if (role is None):
+            await ctx.send(f'Error, could not find the role: {ctx.args[0]}')
+            return
+
+        # Add member to role.
+        member = ctx.author
+        await member.add_roles(role)
+
+        # We did it!
+        await ctx.send(f"Successfully registered for role: {role}!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/src/cogs/roles.py
+++ b/src/cogs/roles.py
@@ -9,8 +9,6 @@ load_dotenv()
 MSGID = os.getenv('823687567206776862')
 GUILD_ID = int(os.getenv('GUILD_ID'))
 
-print(GUILD_ID)
-
 
 class Roles(commands.Cog):
 
@@ -45,7 +43,7 @@ class Roles(commands.Cog):
                 value=entry
             ), roles_map.values())
 
-    @cog_ext.cog_slash(name='addrole', description='Adds a role to your account.', guild_ids=[GUILD_ID], options=[
+    @cog_ext.cog_slash(name='addRole', description='Adds a role to your account.', guild_ids=[GUILD_ID], options=[
         create_option(
             name="role",
             description="The role to add.",
@@ -59,16 +57,21 @@ class Roles(commands.Cog):
         await ctx.defer()
 
         # Fetch the role from the cache.
-        role = discord.utils.get(ctx.guild.roles, name=ctx.args[0])
+        fetched_role = discord.utils.get(ctx.guild.roles, name=ctx.args[0])
 
         # This branch shouldn't happen, but just in case...
-        if (role is None):
-            await ctx.send(f'Error, could not find the role: {ctx.args[0]}')
+        if (fetched_role is None):
+            await ctx.send(f"Error, could not find the role: '{ctx.args[0]}'")
+            return
+
+        # Check prior membership
+        if (fetched_role in ctx.author.roles):
+            await ctx.send(f"You are already part of {role}.")
             return
 
         # Add member to role.
         member = ctx.author
-        await member.add_roles(role)
+        await member.add_roles(fetched_role)
 
         # We did it!
         await ctx.send(f"Successfully registered for role: {role}!")

--- a/src/cogs/roles.py
+++ b/src/cogs/roles.py
@@ -1,10 +1,15 @@
 import discord
 from discord.ext import commands
+from discord_slash import cog_ext, SlashContext
 import os
+from discord_slash.utils.manage_commands import create_choice, create_option
 from dotenv import load_dotenv
 
 load_dotenv()
 MSGID = os.getenv('823687567206776862')
+GUILD_ID = int(os.getenv('GUILD_ID'))
+
+print(GUILD_ID)
 
 
 class Roles(commands.Cog):
@@ -32,6 +37,26 @@ class Roles(commands.Cog):
         "👩‍🔬": "Physics",
         "knighthacks": "knighthacks"
     }
+
+    choices = map(
+        lambda entry:
+            create_choice(
+                name=entry,
+                value=entry
+            ), roles_map.values())
+
+    @cog_ext.cog_slash(name='addrole', description='Adds a role to your account.', guild_ids=[GUILD_ID], options=[
+        create_option(
+            name="role",
+            description="The role to add.",
+            option_type=3,
+            required=True,
+            choices=choices
+        )
+    ])
+    async def _addrole(self, ctx: SlashContext, role: str):
+        await ctx.defer()
+        await ctx.send("Pong!")
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/src/cogs/roles.py
+++ b/src/cogs/roles.py
@@ -57,7 +57,7 @@ class Roles(commands.Cog):
                     ), roles_map.values())
         )
     ])
-    async def _addrole(self, ctx: SlashContext, role: str):
+    async def add_role(self, ctx: SlashContext, role: str):
         # Show the user that the bot is thinking.
         await ctx.defer()
 
@@ -95,7 +95,7 @@ class Roles(commands.Cog):
                     ), roles_map.values())
         )
     ])
-    async def _removerole(self, ctx: SlashContext, role: str):
+    async def remove_role(self, ctx: SlashContext, role: str):
         # Show the user that the bot is thinking.
         await ctx.defer()
 

--- a/src/cogs/roles.py
+++ b/src/cogs/roles.py
@@ -66,12 +66,12 @@ class Roles(commands.Cog):
 
         # This branch shouldn't happen, but just in case...
         if (fetched_role is None):
-            await ctx.send(f"Error: could not find the role: '{ctx.args[0]}'")
+            await ctx.send(f"Error: could not find the role: '{ctx.args[0]}'", hidden=True)
             return
 
         # Check prior membership
         if (fetched_role in ctx.author.roles):
-            await ctx.send(f"You are already part of {role}.")
+            await ctx.send(f"You are already part of {role}.", hidden=True)
             return
 
         # Add member to role.
@@ -79,7 +79,7 @@ class Roles(commands.Cog):
         await member.add_roles(fetched_role)
 
         # We did it!
-        await ctx.send(f"Successfully registered for role: {role}!")
+        await ctx.send(f"Successfully registered for role: {role}!", hidden=True)
 
     @cog_ext.cog_slash(name='removeRole', description='Removes a role from your account.', guild_ids=[GUILD_ID], options=[
         create_option(
@@ -104,12 +104,12 @@ class Roles(commands.Cog):
 
         # This branch shouldn't happen, but just in case...
         if (fetched_role is None):
-            await ctx.send(f"Error: Could not find the role: '{ctx.args[0]}.'")
+            await ctx.send(f"Error: Could not find the role: '{ctx.args[0]}.'", hidden=True)
             return
 
         # Check prior membership
         if (fetched_role not in ctx.author.roles):
-            await ctx.send(f"You are not a member of {role}.")
+            await ctx.send(f"You are not a member of {role}.", hidden=True)
             return
 
         # Add member to role.
@@ -117,7 +117,7 @@ class Roles(commands.Cog):
         await member.remove_roles(fetched_role)
 
         # We did it!
-        await ctx.send(f"Successfully removed role: {role}!")
+        await ctx.send(f"Successfully removed role: {role}!", hidden=True)
 
     @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):

--- a/src/cogs/roles.py
+++ b/src/cogs/roles.py
@@ -59,7 +59,7 @@ class Roles(commands.Cog):
     ])
     async def add_role(self, ctx: SlashContext, role: str):
         # Show the user that the bot is thinking.
-        await ctx.defer()
+        await ctx.defer(hidden=True)
 
         # Fetch the role from the cache.
         fetched_role = discord.utils.get(ctx.guild.roles, name=ctx.args[0])
@@ -97,7 +97,7 @@ class Roles(commands.Cog):
     ])
     async def remove_role(self, ctx: SlashContext, role: str):
         # Show the user that the bot is thinking.
-        await ctx.defer()
+        await ctx.defer(hidden=True)
 
         # Fetch the role from the cache.
         fetched_role = discord.utils.get(ctx.guild.roles, name=ctx.args[0])


### PR DESCRIPTION
Addresses #11 

Adds slash commands:

`/addrole`, `/removerole`, `/addskill`, `/removeskill`,

<img width="285" alt="Screen Shot 2021-06-14 at 10 18 33 PM" src="https://user-images.githubusercontent.com/77477100/121982928-77797300-cd5e-11eb-9de1-42cd9eeb6bc2.png">


Because of slash commands it is also necessary to update you `env` to include the `GUILD_ID`.
